### PR TITLE
Ensure required handlers are always restarted

### DIFF
--- a/test/logger/error_handler_test.exs
+++ b/test/logger/error_handler_test.exs
@@ -3,7 +3,15 @@ defmodule Logger.ErrorHandlerTest do
 
   test "survives after crashes" do
     assert error_log(:info_msg, "~p~n", []) == ""
-    wait_for_handler()
+    wait_for_handler(:error_logger, Logger.ErrorHandler)
+    assert error_log(:info_msg, "~p~n", [:hello]) =~ msg("[info] :hello\n")
+  end
+
+  test "survives after Logger exit" do
+    Process.whereis(Logger)
+      |> Process.exit(:kill)
+    wait_for_logger()
+    wait_for_handler(:error_logger, Logger.ErrorHandler)
     assert error_log(:info_msg, "~p~n", [:hello]) =~ msg("[info] :hello\n")
   end
 

--- a/test/logger_test.exs
+++ b/test/logger_test.exs
@@ -86,4 +86,11 @@ defmodule LoggerTest do
       Process.register(logger, Logger)
     end
   end
+
+  test "Logger.Config survives Logger exit" do
+    Process.whereis(Logger)
+      |> Process.exit(:kill)
+    wait_for_logger()
+    wait_for_handler(Logger, Logger.Config)
+  end
 end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -14,10 +14,23 @@ defmodule Logger.Case do
     ~r/^\d\d\:\d\d\:\d\d\.\d\d\d #{Regex.escape(msg)}$/
   end
 
-  def wait_for_handler() do
-    unless Logger.ErrorHandler in GenEvent.which_handlers(:error_logger) do
+  def wait_for_handler(manager, handler) do
+    unless handler in GenEvent.which_handlers(manager) do
       :timer.sleep(10)
-      wait_for_handler()
+      wait_for_handler(manager, handler)
+    end
+  end
+
+  def wait_for_logger() do
+    try do
+      GenEvent.which_handlers(Logger)
+    else
+      _ ->
+        :ok
+    catch
+      :exit, _ ->
+        :timer.sleep(10)
+        wait_for_logger()
     end
   end
 


### PR DESCRIPTION
Changes `Logger.Supervisor` to `rest_for_one`:
- `Logger.Config` is before other handlers, and if it crashes all the other handlers will be restarted. This tries to ensure we have the sync protection.
- `Logger.ErrorHandler` is after the other handlers, there is no point forwarding messages when there is no handler to handler them. Also we don't want it crashing to bring down the other handlers.
- `Task` must be after the `Logger.Watcher` `Supervisor` to ensure it restarts the backends.

Changes the `Logger.Watcher` `Supervisor` to `one_for_one`. This is required just in case the starter `Task` fails and is restarted causing duplicate children. This has the side effect of preventing unintentional duplicate handlers on `Logger`.

Changes how `Logger.Watcher` works so that all backends are started concurrently. This provides the following features:
- Backends are started as fast as possible
- Simplifies starter `Task` code so it does not need to handle a backend that can't be started
- Starting the backends does not block the `Logger.ErrorHandler` being started
