### PR TITLE
Add config reloader

### DIFF
--- a/lib/logger/deleter.ex
+++ b/lib/logger/deleter.ex
@@ -1,0 +1,34 @@
+defmodule Logger.Deleter do
+  @moduledoc false
+
+  def start_link([]), do: :ignore
+
+  def start_link(handlers) do
+    :proc_lib.start_link(__MODULE__, :init, [self(), handlers])
+  end
+
+  def init(parent, handlers) do
+    delete_handlers(handlers)
+    :proc_lib.init_ack(parent, :ignore)
+  end
+
+  defp delete_handlers(handlers) do
+    Enum.each(handlers, &delete_handler/1)
+  end
+
+  defp delete_handler(handler) do
+    case :error_logger.delete_report_handler(handler) do
+      {:error, :module_not_found} ->
+        :ok
+      _other ->
+        put_handler(handler)
+    end
+  end
+
+  defp put_handler(handler) do
+    handlers = Application.get_env(:logger, :deleted_handlers)
+    handlers = HashSet.put(handlers, handler)
+    Application.put_env(:logger, :deleted_handlers, handlers)
+  end
+
+end

--- a/lib/logger/reloader.ex
+++ b/lib/logger/reloader.ex
@@ -1,0 +1,25 @@
+defmodule Logger.Reloader do
+
+
+  use GenServer
+  @name Logger.Reloader
+
+  def start_link(), do: GenServer.start_link(__MODULE__, nil, [name: @name])
+
+  def reload(), do: GenServer.call(@name, :reload)
+
+  def init(state) do
+    {:ok, state}
+  end
+
+  def handle_call(:reload, _from, state) do
+    :ok = Supervisor.terminate_child(Logger.Supervisor, Logger.Watcher.Supervisor)
+    case Supervisor.restart_child(Logger.Supervisor, Logger.Watcher.Supervisor) do
+      {:ok, _pid} ->
+        {:reply, :ok, state}
+      # Something went wrong, stopping will trigger a restart of everything
+      {:error, reason} ->
+        {:stop, reason, state}
+    end
+  end
+end

--- a/lib/logger/watcher/supervisor.ex
+++ b/lib/logger/watcher/supervisor.ex
@@ -1,0 +1,33 @@
+defmodule Logger.Watcher.Supervisor do
+  @moduledoc false
+
+  use Supervisor
+  @name Logger.Watch.Supervisor
+
+  def start_link() do
+    Supervisor.start_link(__MODULE__, nil, [name: @name])
+  end
+
+  def init(nil) do
+    otp_reports? = Application.get_env(:logger, :handle_otp_reports)
+    threshold    = Application.get_env(:logger, :discard_threshold_for_error_logger)
+
+    handlers =
+      for backend <- Application.get_env(:logger, :backends) do
+        {Logger, Logger.translate_backend(backend), []}
+      end
+
+    delete_handlers = if otp_reports?, do: [:error_logger_tty_h], else: []
+
+    children = [worker(Logger.Watcher, [Logger, Logger.Config, []],
+                 [id: Logger.Config, function: :watcher]),
+                supervisor(Logger.Watcher, [handlers]),
+                worker(Logger.Deleter, [delete_handlers], [restart: :transient]),
+                worker(Logger.Watcher,
+                  [:error_logger, Logger.ErrorHandler, {otp_reports?, threshold}],
+                  [id: Logger.ErrorHandler, function: :watcher])]
+
+    supervise(children, [strategy: :rest_for_one])
+  end
+
+end

--- a/test/logger/reloader_test.exs
+++ b/test/logger/reloader_test.exs
@@ -1,0 +1,109 @@
+defmodule Logger.ReloaderTest do
+  use Logger.Case
+  require Logger
+
+  setup do
+    on_exit(
+      fn() ->
+        # Reset so one failed test won't break others
+        _ = Application.stop(:logger)
+        :ok = Application.unload(:logger)
+        # load will set default configs
+        :ok = Application.load(:logger)
+        :ok = Application.start(:logger)
+      end)
+    :ok
+  end
+
+  test "reload/0 add and removes backend" do
+    backends = Application.get_env(:logger, :backends, [])
+    Application.put_env(:logger, :backends, [])
+
+    assert :ok = Logger.Reloader.reload()
+
+    assert capture_log(fn ->
+      assert Logger.debug("hello", []) == :ok
+    end) == ""
+
+    Application.put_env(:logger, :backends, backends)
+
+    assert :ok = Logger.Reloader.reload()
+
+    assert capture_log(fn ->
+      assert Logger.debug("hello", []) == :ok
+    end) =~ msg("[debug] hello")
+
+  end
+
+  test "reload/0 changes config" do
+    truncate = Application.get_env(:logger, :truncate, 8096)
+    Application.put_env(:logger, :truncate, 4)
+
+    assert :ok = Logger.Reloader.reload()
+
+    assert capture_log(fn ->
+      assert Logger.debug("hello", []) == :ok
+    end) =~ msg("[debug] hell (truncated)")
+
+    Application.put_env(:logger, :truncate, truncate)
+
+    assert :ok = Logger.Reloader.reload()
+
+    assert capture_log(fn ->
+      assert Logger.debug("hello", []) == :ok
+    end) =~ msg("[debug] hello")
+
+  end
+
+  test "reload/0 starts and stops handle_otp_reports" do
+    otp_reports? = Application.get_env(:logger, :handle_otp_reports, true)
+    Application.put_env(:logger, :handle_otp_reports, false)
+
+    assert :ok = Logger.Reloader.reload()
+
+    assert capture_log(fn ->
+      assert :error_logger.info_msg('hello') == :ok
+    end) == ""
+
+    Application.put_env(:logger, :handle_otp_reports, :true)
+
+    assert :ok = Logger.Reloader.reload()
+
+    assert capture_log(fn ->
+      assert :error_logger.info_msg('hello') == :ok
+    end) =~ msg("[info] hello")
+
+    Application.put_env(:logger, :handle_otp_reports, otp_reports?)
+
+  end
+
+  test "reload/0 add tty handler on stop if deleted" do
+    refute Enum.member?(GenEvent.which_handlers(:error_logger), :error_logger_tty_h)
+    Application.stop(:logger)
+    assert Enum.member?(GenEvent.which_handlers(:error_logger), :error_logger_tty_h)
+
+    Application.put_env(:logger, :handle_otp_reports, false)
+    :ok = Application.start(:logger)
+    assert Enum.member?(GenEvent.which_handlers(:error_logger), :error_logger_tty_h)
+
+    :ok = Application.stop(:logger)
+    assert Enum.member?(GenEvent.which_handlers(:error_logger), :error_logger_tty_h)
+
+    Application.start(:logger)
+    Application.put_env(:logger, :handle_otp_reports, true)
+    assert :ok = Logger.Reloader.reload()
+
+    assert :ok = Application.stop(:logger)
+    assert Enum.member?(GenEvent.which_handlers(:error_logger), :error_logger_tty_h)
+
+  end
+
+  test "reload/0 with bad config crashes logger" do
+    Application.put_env(:logger, :backends, nil)
+    catch_exit(Logger.Reloader.reload())
+    # wait for restart limits to be exceeded and logger exit
+    :timer.sleep(500)
+    refute Enum.any?(:application.which_applications(), &(elem(&1, 0) == :logger))
+  end
+
+end


### PR DESCRIPTION
Here is a working config reloader for #6. A more complicated version could be created which makes calls for individual handlers (instead of restarting a supervisor) but given how this will be used I did not think it was worth it.

Unfortunately the tests print out the `logger` application stopped a lot. I think this can be solved with `capture_io` or `capture_log` but it is a pain because `:error_logger_tty_h` links to `:user`. I couldn't get this to work and the `error_logger_tty_h` adding on stop test to pass. @josevalim will probably want to solve this before merging into `elixir`.
